### PR TITLE
Check for null or non-object "value" when using model options

### DIFF
--- a/addon/components/smd-form-control.js
+++ b/addon/components/smd-form-control.js
@@ -80,8 +80,10 @@ export default Component.extend({
           }
           option.value = obj;
 
-          if (obj.id === value.get('id')) {
-            option.selected = true;
+          if(value !== null && typeof(value) === 'object' && value.get) {
+            if (obj.id === value.get('id')) {
+              option.selected = true;
+            }
           }
 
           array.push(option);


### PR DESCRIPTION
It is possible for value to be null or not an object when using modelOptions. For example when a radio form is initialised to null, but the possible values are calculated from modelOptions.